### PR TITLE
Adding DT5790 coincidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ source/ADAQReadout/build/*
 source/ASIM/build/*
 source/ASIM/example/lib/*
 
+# Ignore local boost files
+*include/boost/*
+
 # Miscellaneous
 templates/CAENAcquisitionTemplate/build/*
 templates/CAENAcquisitionTemplate/bin/*
@@ -50,4 +53,4 @@ ref/caen/drivers/CAENUSBdrvB-1.4/.CAENUSBdrvB.o.cmd
 ref/caen/drivers/CAENUSBdrvB-1.4/.tmp_versions/
 ref/caen/drivers/CAENUSBdrvB-1.4/CAENUSBdrvB.ko
 ref/caen/drivers/CAENUSBdrvB-1.4/CAENUSBdrvB.mod.c
-
+caen/software/archive/*


### PR DESCRIPTION
Adds ability to enable coincidence for PSD firmware for just DT5790 to ADAQDigitizer; SetTriggerCoincidence now looks for firmware type and board model, and will write the registers necessary for PSD coincidence if PSD firmware is found, and the board is a DT5790. This does mean nothing will happen if the user tries to enable coincidence and the board runs on something other than standard firmware or PSD, or if the user tries to enable coincidence on a PSD board other than the DT5790. 