### PR TITLE
Added user setting of coincidence window and channels

### DIFF
--- a/source/ADAQControl/include/ADAQDigitizer.hh
+++ b/source/ADAQControl/include/ADAQDigitizer.hh
@@ -110,7 +110,7 @@ public:
 
   int SetTriggerEdge(int, string);
 
-  int SetTriggerCoincidence(bool, int, int);
+  int SetTriggerCoincidence(bool, int, int, int, int);
 
   // Acquisition control
 

--- a/source/ADAQControl/include/ADAQDigitizer.hh
+++ b/source/ADAQControl/include/ADAQDigitizer.hh
@@ -110,7 +110,7 @@ public:
 
   int SetTriggerEdge(int, string);
 
-  int SetTriggerCoincidence(bool, int);
+  int SetTriggerCoincidence(bool, int, int);
 
   // Acquisition control
 


### PR DESCRIPTION
ADAQDigitizer::SetTriggerCoincidence now takes Window length, and Channel1 and Channel2 as arguments from ADAQVMEHandler, allowing user to set the coincidence window length, and choose which two channels should be enabled for coincidence. Registers to write are then determined from the channels passed by the user.

Also added coincidence capability for V1720.