### PR TITLE
Full V1725 Coincidence added.

### DIFF
--- a/source/ADAQControl/include/ADAQDigitizer.hh
+++ b/source/ADAQControl/include/ADAQDigitizer.hh
@@ -110,7 +110,7 @@ public:
 
   int SetTriggerEdge(int, string);
 
-  int SetTriggerCoincidence(bool, int, int);
+  int SetTriggerCoincidence(bool, int, int, int, int);
 
   // Acquisition control
 

--- a/source/ADAQControl/include/ADAQDigitizer.hh
+++ b/source/ADAQControl/include/ADAQDigitizer.hh
@@ -110,7 +110,7 @@ public:
 
   int SetTriggerEdge(int, string);
 
-  int SetTriggerCoincidence(bool, int);
+  int SetTriggerCoincidence(bool, int, int);
 
   // Acquisition control
 

--- a/source/ADAQControl/src/ADAQDigitizer.cc
+++ b/source/ADAQControl/src/ADAQDigitizer.cc
@@ -617,9 +617,9 @@ int ADAQDigitizer::SetTriggerCoincidence(bool Enable, int Level, int Window, int
         uint32_t TriggerLatency_Mask = 0;
         uint32_t TriggerLatency_And_Mask = 0x7ffffc00;
         uint32_t TriggerLatency_Value = 0x9;
-        
+
         uint32_t Pwr = Channel1 % 2;
-        if (Channel1+(-1)**Pwr == Channel2){
+        if (Channel1+pow(-1,Pwr) == Channel2){
           uint32_t TriggerLatency_Value = 0x2;
         }    
 
@@ -649,7 +649,7 @@ int ADAQDigitizer::SetTriggerCoincidence(bool Enable, int Level, int Window, int
           // if the other channel is 1 greater, and if it is odd, it is paired if the other channel
           // is one less. 
 
-        if (Channel1+(-1)**Pwr == Channel2){
+        if (Channel1+pow(-1,Pwr) == Channel2){
           uint32_t AlgorithmControl_Mask = 0;
 
           uint32_t AlgorithmControl_Value = 0x60;


### PR DESCRIPTION
V1725/30 coincidence capability added. Still can only set PSD coincidence to two level. 

V1725/30 has paired channels, and true coincidence (neither channel will trigger without the other also triggering) can only be enabled within a couple. Outside of the couple, one channel, usually the lower value, ie. Ch 0 out of Ch 0 & 2, will operate on OR logic with the other channel, while the second channel will operate on AND logic with the first. Unclear why this occurs, but this is also how it is implemented in CoMPASS. 